### PR TITLE
Changed source of IP to DynDNS

### DIFF
--- a/ddns.php
+++ b/ddns.php
@@ -65,7 +65,7 @@ catch (Exception $e)
 // http://stackoverflow.com/questions/3097589/getting-my-public-ip-via-api
 function getIP()
 {
-  return trim(file_get_contents('http://icanhazip.com'));
+  return trim(file_get_contents('http://checkip.dyndns.org/'));
 }
 
 


### PR DESCRIPTION
icanhazip.com was returning an IPv6 IP for me which was causing the
cloudflare update to fail. DynDNS does the same thing but returns an
IPv4 ip, plus DynDNS is more well known than icanhazip.com
