### PR TITLE
Fixed getIP() for ipv6 users

### DIFF
--- a/ddns.php
+++ b/ddns.php
@@ -65,7 +65,7 @@ catch (Exception $e)
 // http://stackoverflow.com/questions/3097589/getting-my-public-ip-via-api
 function getIP()
 {
-  return trim(file_get_contents('http://icanhazip.com'));
+  return trim(file_get_contents('http://ipv4.icanhazip.com/'));
 }
 
 


### PR DESCRIPTION
Uses the ipv4 forced option for icanhazip.com, making it so IPv6 users
can still use the script by falling back on ipv4
