### PR TITLE
change extension for crontab example from .sh to .php

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Edit config.php - enter your CloudFlare credentials and domain details.
 ./ddns.php
 ```
 
-If everythings works, put it in your crontab.
+If everything works, put it in your crontab.
 
 ```
 0 * * * * /path/to/cloudflare-ddns/ddns.php -s


### PR DESCRIPTION
There's no .sh file in the repo, looks like a typo to me. Fixed "everythings" typo as well.
