### PR TITLE
CloudFlare now require User-Agent for API requests

### DIFF
--- a/Cloudflare.php
+++ b/Cloudflare.php
@@ -50,7 +50,7 @@ class Cloudflare
     $headers = [
       'X-Auth-Email: ' . $this->email,
       'X-Auth-Key: ' . $this->apiKey,
-      'User-Agent: {__FILE__}'
+      'User-Agent: cloudflare-php'
     ];
 
     $url = self::ENDPOINT . ltrim($endpoint, '/');


### PR DESCRIPTION
Added 'User-Agent' to $headers in **public function request**
