### PR TITLE
Feature/api mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ git clone https://github.com/lyoshenka/cloudflare-ddns.git
 cd cloudflare-ddns
 cp config.php.skel config.php
 ### Edit config.php - enter your CloudFlare credentials and domain details
+```
+
+### Local mode
+
+Uses the public IP of the machine you're running this on to update your CF record.
+
+```
 ./ddns.php
 ```
 
@@ -17,6 +24,14 @@ If everything works, put it in your crontab.
 ```
 0 * * * * /path/to/cloudflare-ddns/ddns.php -s
 ``` 
+
+### API mode
+
+You can put this script on a server and use the DynDns option of your router to trigger the IP update.
+
+To do this set ``auth_token`` in your config which enables API mode.
+
+Then you can call the script like this: ``yourdomain/ddns.php?auth_token=yourtoken&ip=127.0.0.1``
 
 ## License
 

--- a/config.php.skel
+++ b/config.php.skel
@@ -10,5 +10,9 @@ return array(
 
   'ttl' => 1, // a TTL of 1 means "automatic". if you want a fixed TTL, make it >= 120 (seconds)
 
-  'protocol' => 'ipv4' // what protocol to use to get the ip address. Possible values: "ipv4", "ipv6", "auto".
+  'protocol' => 'ipv4', // what protocol to use to get the ip address. Possible values: "ipv4", "ipv6", "auto".
+
+  'auth_token' => '' // (optional) if set this is used for authentication and restricting usage to api mode
+                     // generate a random string here:
+                     // https://www.random.org/strings/?num=1&len=20&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new
 );

--- a/ddns.php
+++ b/ddns.php
@@ -26,7 +26,34 @@ $api = new Cloudflare($config['cloudflare_email'], $config['cloudflare_api_key']
 $domain     = $config['domain'];
 $recordName = $config['record_name'];
 
-$ip = getIP($config['protocol']);
+if (isset($config['auth_token']) && $config['auth_token'] != '')
+{
+    if (empty($_GET['auth_token']))
+    {
+        echo "missing auth_token";
+        return 1;
+    }
+
+    if (empty($_GET['ip']))
+    {
+        echo "missing ip";
+        return 1;
+    }
+
+    if ($_GET['auth_token'] == $config['auth_token'])
+    {
+        $ip = $_GET['ip'];
+    }
+    else
+    {
+        echo "invalid auth_token";
+        return 1;
+    }
+}
+else
+{
+    $ip = getIP($config['protocol']);
+}
 
 $verbose = !isset($argv[1]) || $argv[1] != '-s';
 


### PR DESCRIPTION
This adds an API mode, which enables routers like FritzBoxes to trigger an IP-change via their DynDNS option by calling an URL with specific parameters.